### PR TITLE
Update neo.config to work with JUNO's LSF configuration. 

### DIFF
--- a/config/neo.config
+++ b/config/neo.config
@@ -14,7 +14,11 @@ executor {
   // Our (JUNO) LSF is configured to use memory per core
   // so this should be set to _false_. But need to adjust
   // the memory settings below to reflect this.
+  // And also need to set perTaskReserve = true
+  // for this to work
+  //
   perJobMemLimit = false
+  perTaskReserve = true
   submitRateLimit = '1 sec' // dkfz.config was '3 sec' but I think 1 is enough
 }
 
@@ -45,11 +49,19 @@ https://gatk.broadinstitute.org/hc/en-us/community/posts/15524085820699-MarkDupl
   //     cpus   = { check_max( 2 * task.attempt, 'cpus' ) }
   //     memory = { check_max( 4.GB * task.attempt, 'memory' ) }
   // }
+  // withName: 'BWAMEM1_MEM|BWAMEM2_MEM' {
+  //     cpus   = { check_max( 24 * task.attempt, 'cpus' ) }
+  //     memory = { check_max( 30.GB * task.attempt, 'memory' ) }
+  // }
 
+  withName: 'BWAMEM1_MEM|BWAMEM2_MEM' {
+      cpus   = { 24 * task.attempt }
+      memory = { 24.GB * task.attempt }
+  }
 
   withName: 'GATK4_MARKDUPLICATES' {
     cpus = { 48 }
-    memory = { 48.GB } // 48 cores * 1GB per core
+    memory = { 96.GB } // 48 cores * 1GB per core
     time = { task.attempt < 3 ? 18.h * task.attempt  : 72.h }
     ext.args = "--MAX_RECORDS_IN_RAM 20000000 --SORTING_COLLECTION_SIZE_RATIO .15"
   }
@@ -73,7 +85,13 @@ https://gatk.broadinstitute.org/hc/en-us/community/posts/15524085820699-MarkDupl
   }
 
   withName: ".*NFCORE_SAREK:SAREK:FASTQC" {
-    memory = { 10.GB } // max allowed by FASTQC
+    memory = { 12.GB } // max allowed by FASTQC
+    time = { task.attempt < 3 ? 1.h * task.attempt  : 4.h }
+  }
+
+  withName: "FASTP" {
+    cpus   = { 12 }
+    memory = { 12.GB }
     time = { task.attempt < 3 ? 1.h * task.attempt  : 4.h }
   }
 

--- a/config/neo.config
+++ b/config/neo.config
@@ -10,8 +10,12 @@
 executor {
   name = "lsf"
   queueSize = 5000000000
-  perJobMemLimit = true
-  submitRateLimit = '3 sec' // dkfz.config
+  //
+  // Our (JUNO) LSF is configured to use memory per core
+  // so this should be set to _false_. But need to adjust
+  // the memory settings below to reflect this.
+  perJobMemLimit = false
+  submitRateLimit = '1 sec' // dkfz.config was '3 sec' but I think 1 is enough
 }
 
 process {
@@ -31,32 +35,45 @@ https://gatk.broadinstitute.org/hc/en-us/community/posts/15524085820699-MarkDupl
 
 */
 
-  withName: ".*BAM_MARKDUPLICATES:GATK4_MARKDUPLICATES" {
+  // From base.config
+  //
+  // withName: 'GATK4_MARKDUPLICATES|GATK4SPARK_MARKDUPLICATES' {
+  //     cpus   = { check_max( 6 * task.attempt, 'cpus' ) }
+  //     memory = { check_max( 30.GB * task.attempt, 'memory' ) }
+  // }
+  // withName:'GATK4_APPLYBQSR|GATK4SPARK_APPLYBQSR|GATK4_BASERECALIBRATOR|GATK4SPARK_BASERECALIBRATOR|GATK4_GATHERBQSRREPORTS'{
+  //     cpus   = { check_max( 2 * task.attempt, 'cpus' ) }
+  //     memory = { check_max( 4.GB * task.attempt, 'memory' ) }
+  // }
+
+
+  withName: 'GATK4_MARKDUPLICATES' {
     cpus = { 48 }
-    memory = { 4.GB }
+    memory = { 48.GB } // 48 cores * 1GB per core
     time = { task.attempt < 3 ? 18.h * task.attempt  : 72.h }
     ext.args = "--MAX_RECORDS_IN_RAM 20000000 --SORTING_COLLECTION_SIZE_RATIO .15"
   }
 
-  withName: ".*BAM_BASERECALIBRATOR:GATK4_BASERECALIBRATOR" {
-    cpus = { 20 }
-    memory = { 1.GB }
-    time = { task.attempt < 3 ? 5.h * task.attempt  : 15.h }
+  withName: 'GATK4_APPLYBQSR|GATK4_BASERECALIBRATOR' {
+    cpus = { 12 * task.attempt }
+    memory = { 24.GB * task.attempt } // 24 cores * 2GB per core
+    time = { task.attempt < 3 ? 6.h * task.attempt  : 18.h }
   }
 
   withName: ".*BAM_APPLYBQSR:CRAM_MERGE_INDEX_SAMTOOLS:MERGE_CRAM" {
     cpus = { 20 }
-    memory = { 1.GB }
+    memory = { 20.GB } // 20 cores * 1GB per core
     time = { task.attempt < 3 ? 7.h * task.attempt  : 21.h }
   }
 
   withName: ".*CRAM_SAMPLEQC:CRAM_QC_RECAL:SAMTOOLS_STATS" {
     cpus = { 20 }
-    memory = { 1.GB }
+    memory = { 20.GB } // 20 cores * 1GB per core
     time = { task.attempt < 3 ? 7.h * task.attempt  : 21.h }
   }
 
   withName: ".*NFCORE_SAREK:SAREK:FASTQC" {
+    memory = { 10.GB } // max allowed by FASTQC
     time = { task.attempt < 3 ? 1.h * task.attempt  : 4.h }
   }
 


### PR DESCRIPTION
To get things to memory and cpus settings to work correctly and not have to change the modules main.nf code the following needed to be done for JUNO's LSF
   - perJobMemLimit=false
   - perTaskReserve=true
   - Note memory/cpus needs to be an integer (again maybe a JUNO thing). So memory=10 cpus=4 does not appear to work as 10/4 == 2.5
   - As a hack to help this work set memory == 12 if you do not also explicitly set cpus
